### PR TITLE
評価機能を入力必須に変更しバリデーションが表示されるように修正

### DIFF
--- a/app/models/tasting_note.rb
+++ b/app/models/tasting_note.rb
@@ -5,8 +5,9 @@ class TastingNote < ApplicationRecord
   belongs_to :shop, optional: true
 
   # Validations
-  validates :preference_score, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }, allow_nil: true
-  validates :acidity_score, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }, allow_nil: true
-  validates :bitterness_score, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }, allow_nil: true
-  validates :sweetness_score, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }, allow_nil: true
+  validates :preference_score, presence: true
+  validates :acidity_score, presence: true
+  validates :bitterness_score, presence: true
+  validates :sweetness_score, presence: true
+  validates :brew_method, presence: true
 end

--- a/spec/models/tasting_note_spec.rb
+++ b/spec/models/tasting_note_spec.rb
@@ -9,142 +9,30 @@ RSpec.describe TastingNote, type: :model do
 
   describe 'validations' do
     describe 'preference_score' do
-      it 'nilを許容' do
+      it 'nilを許容しない' do
         tasting_note = build_tasting_note(preference_score: nil)
-        expect(tasting_note).to be_valid
-      end
-
-      it '1以上の値を許容' do
-        tasting_note = build_tasting_note(preference_score: 1)
-        expect(tasting_note).to be_valid
-      end
-
-      it '5以下の値を許容' do
-        tasting_note = build_tasting_note(preference_score: 5)
-        expect(tasting_note).to be_valid
-      end
-
-      it '0を拒否' do
-        tasting_note = build_tasting_note(preference_score: 0)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:preference_score]).to be_present
-      end
-
-      it '6を拒否' do
-        tasting_note = build_tasting_note(preference_score: 6)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:preference_score]).to be_present
-      end
-
-      it '小数を拒否' do
-        tasting_note = build_tasting_note(preference_score: 3.5)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:preference_score]).to be_present
+        expect(tasting_note).to_not be_valid
       end
     end
 
     describe 'acidity_score' do
-      it 'nilを許容' do
+      it 'nilを許容しない' do
         tasting_note = build_tasting_note(acidity_score: nil)
-        expect(tasting_note).to be_valid
-      end
-
-      it '1以上の値を許容' do
-        tasting_note = build_tasting_note(acidity_score: 1)
-        expect(tasting_note).to be_valid
-      end
-
-      it '5以下の値を許容' do
-        tasting_note = build_tasting_note(acidity_score: 5)
-        expect(tasting_note).to be_valid
-      end
-
-      it '0を拒否' do
-        tasting_note = build_tasting_note(acidity_score: 0)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:acidity_score]).to be_present
-      end
-
-      it '6を拒否' do
-        tasting_note = build_tasting_note(acidity_score: 6)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:acidity_score]).to be_present
-      end
-
-      it '小数を拒否' do
-        tasting_note = build_tasting_note(acidity_score: 2.5)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:acidity_score]).to be_present
+        expect(tasting_note).to_not be_valid
       end
     end
 
     describe 'bitterness_score' do
-      it 'nilを許容' do
+      it 'nilを許容しない' do
         tasting_note = build_tasting_note(bitterness_score: nil)
-        expect(tasting_note).to be_valid
-      end
-
-      it '1以上の値を許容' do
-        tasting_note = build_tasting_note(bitterness_score: 1)
-        expect(tasting_note).to be_valid
-      end
-
-      it '5以下の値を許容' do
-        tasting_note = build_tasting_note(bitterness_score: 5)
-        expect(tasting_note).to be_valid
-      end
-
-      it '0を拒否' do
-        tasting_note = build_tasting_note(bitterness_score: 0)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:bitterness_score]).to be_present
-      end
-
-      it '6を拒否' do
-        tasting_note = build_tasting_note(bitterness_score: 6)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:bitterness_score]).to be_present
-      end
-
-      it '小数を拒否' do
-        tasting_note = build_tasting_note(bitterness_score: 4.5)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:bitterness_score]).to be_present
+        expect(tasting_note).to_not be_valid
       end
     end
 
     describe 'sweetness_score' do
-      it 'nilを許容' do
+      it 'nilを許容しない' do
         tasting_note = build_tasting_note(sweetness_score: nil)
-        expect(tasting_note).to be_valid
-      end
-
-      it '1以上の値を許容' do
-        tasting_note = build_tasting_note(sweetness_score: 1)
-        expect(tasting_note).to be_valid
-      end
-
-      it '5以下の値を許容' do
-        tasting_note = build_tasting_note(sweetness_score: 5)
-        expect(tasting_note).to be_valid
-      end
-
-      it '0を拒否' do
-        tasting_note = build_tasting_note(sweetness_score: 0)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:sweetness_score]).to be_present
-      end
-
-      it '6を拒否' do
-        tasting_note = build_tasting_note(sweetness_score: 6)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:sweetness_score]).to be_present
-      end
-
-      it '小数を拒否' do
-        tasting_note = build_tasting_note(sweetness_score: 1.5)
-        expect(tasting_note).not_to be_valid
-        expect(tasting_note.errors[:sweetness_score]).to be_present
+        expect(tasting_note).to_not be_valid
       end
     end
   end

--- a/spec/requests/tasting_notes_spec.rb
+++ b/spec/requests/tasting_notes_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "TastingNotes", type: :request do
   let!(:other_user) { FactoryBot.create(:user) }
   let!(:coffee_bean) { FactoryBot.create(:coffee_bean, user: user) }
   let!(:other_coffee_bean) { FactoryBot.create(:coffee_bean, user: other_user, name: 'Other Bean') }
-  let!(:tasting_note) { TastingNote.create!(user: user, coffee_bean: coffee_bean, preference_score: 5) }
-  let!(:other_tasting_note) { TastingNote.create!(user: other_user, coffee_bean: other_coffee_bean, preference_score: 3) }
+  let!(:tasting_note) { TastingNote.create!(user: user, coffee_bean: coffee_bean, preference_score: 5, acidity_score: 3, bitterness_score: 3, sweetness_score: 4, brew_method: 'ハンドドリップ') }
+  let!(:other_tasting_note) { TastingNote.create!(user: other_user, coffee_bean: other_coffee_bean, preference_score: 3, acidity_score: 2, bitterness_score: 4, sweetness_score: 3, brew_method: 'エスプレッソ') }
 
   before do
     post user_session_path, params: { user: { email: user.email, password: 'password123' } }
@@ -69,17 +69,23 @@ RSpec.describe "TastingNotes", type: :request do
 
       it "作成したテイスティングノートが現在のユーザーと関連付けられること" do
         post coffee_bean_tasting_notes_path(coffee_bean), params: {
-          tasting_note: { preference_score: 5 }
+          tasting_note: {
+            preference_score: 5,
+            acidity_score: 3,
+            bitterness_score: 3,
+            sweetness_score: 4,
+            brew_method: 'ハンドドリップ'
+          }
         }
         expect(TastingNote.last.user).to eq(user)
       end
     end
 
     context "無効なパラメータの場合" do
-      it "無効なスコアでテイスティングノートを作成できないこと" do
+      it "必須フィールドが欠けている場合、テイスティングノートを作成できないこと" do
         expect {
           post coffee_bean_tasting_notes_path(coffee_bean), params: {
-            tasting_note: { preference_score: 10 }
+            tasting_note: { preference_score: 5 }
           }
         }.not_to change(TastingNote, :count)
 
@@ -126,10 +132,10 @@ RSpec.describe "TastingNotes", type: :request do
     end
 
     context "無効なパラメータの場合" do
-      it "テイスティングノートを更新できないこと" do
+      it "必須フィールドを空にすると更新できないこと" do
         original_score = tasting_note.preference_score
         patch coffee_bean_tasting_note_path(coffee_bean, tasting_note), params: {
-          tasting_note: { preference_score: 10 }
+          tasting_note: { preference_score: nil }
         }
         expect(tasting_note.reload.preference_score).to eq(original_score)
         expect(response).to have_http_status(:unprocessable_entity)


### PR DESCRIPTION
https://github.com/n-wata-ru/exit_examination_rails/issues/72

<img width="675" height="579" alt="Image" src="https://github.com/user-attachments/assets/691fe56e-19f0-47f2-8077-af79aec4cdb9" />

<img width="591" height="740" alt="Image" src="https://github.com/user-attachments/assets/45a4f402-976e-4c18-a21c-3a82cf903e11" />

<img width="661" height="532" alt="Image" src="https://github.com/user-attachments/assets/e8f6905e-0343-4a22-b4c7-1f9626b75d70" />